### PR TITLE
Fix autoload namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "symfony/yaml": "^3.0"
     },
     "autoload": {
-        "psr-4": { "Toinou97434\\SummernoteBundle\\": "" }
+        "psr-4": { "Toinou\\SummernoteBundle\\": "" }
     }
 }


### PR DESCRIPTION
Autoload configuration written in current composer.json is wrong. PHP Classes exist in `Toinou` namespace, not in `Toinou97434`.